### PR TITLE
Add SimpleFIN Bridge sync

### DIFF
--- a/app/Console/Commands/SyncSimpleFinAccounts.php
+++ b/app/Console/Commands/SyncSimpleFinAccounts.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\SyncSimpleFinAccounts as SyncSimpleFinAccountsJob;
+use App\Models\SimpleFinToken;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Queue;
+
+class SyncSimpleFinAccounts extends Command
+{
+    protected $signature = 'app:simplefin:sync {userId?}';
+
+    protected $description = 'Sync accounts and transactions via SimpleFIN Bridge';
+
+    public function handle(): int
+    {
+        $userId = $this->argument('userId');
+
+        $tokens = SimpleFinToken::when($userId, function ($q) use ($userId) {
+            $q->where('user_id', $userId);
+        })->get();
+
+        $tokens->each(function ($token) {
+            SyncSimpleFinAccountsJob::dispatch($token);
+        });
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Jobs/SyncSimpleFinAccounts.php
+++ b/app/Jobs/SyncSimpleFinAccounts.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\SimpleFinToken;
+use App\Services\SimpleFinService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class SyncSimpleFinAccounts implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public SimpleFinToken $token;
+
+    public function __construct(SimpleFinToken $token)
+    {
+        $this->token = $token;
+    }
+
+    public function handle(): void
+    {
+        $service = new SimpleFinService();
+        $service->sync($this->token);
+    }
+}

--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -83,6 +83,7 @@ class Account extends Model
         'opening_balance',
         'account_group_id',
         'currency_id',
+        'simplefin_account_id',
     ];
 
     protected $casts = [

--- a/app/Models/SimpleFinToken.php
+++ b/app/Models/SimpleFinToken.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class SimpleFinToken extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'access_url',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\DatabaseNotification;
 use Illuminate\Notifications\DatabaseNotificationCollection;
@@ -193,5 +194,10 @@ class User extends Authenticatable implements MustVerifyEmail, Onboardable
     public function unhandledReceivedMail(): HasMany
     {
         return $this->hasMany(ReceivedMail::class)->unhandled();
+    }
+
+    public function simpleFinToken(): HasOne
+    {
+        return $this->hasOne(SimpleFinToken::class);
     }
 }

--- a/app/Services/SimpleFinService.php
+++ b/app/Services/SimpleFinService.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Account;
+use App\Models\AccountEntity;
+use App\Models\SimpleFinToken;
+use App\Models\Transaction;
+use App\Models\TransactionDetailStandard;
+use App\Models\TransactionType;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Http;
+
+class SimpleFinService
+{
+    public function sync(SimpleFinToken $token): void
+    {
+        $accessUrl = $token->access_url;
+        $parts = parse_url($accessUrl);
+        $username = $parts['user'] ?? null;
+        $password = $parts['pass'] ?? null;
+        $base = $parts['scheme'].'://'.$parts['host'].($parts['path'] ?? '');
+
+        $response = Http::withBasicAuth($username, $password)->get($base.'/accounts');
+        if ($response->failed()) {
+            return;
+        }
+
+        $data = $response->json();
+        $user = $token->user;
+        $accountGroup = $user->accountGroups()->firstOrCreate(['name' => 'SimpleFIN']);
+        $currency = $user->baseCurrency() ?? $user->currencies()->first();
+
+        foreach ($data['accounts'] ?? [] as $remote) {
+            $accountEntity = $user->accounts()->where('name', $remote['name'])->first();
+            if (!$accountEntity) {
+                $account = Account::create([
+                    'opening_balance' => $remote['balance'] ?? 0,
+                    'account_group_id' => $accountGroup->id,
+                    'currency_id' => $currency->id,
+                    'simplefin_account_id' => $remote['id'] ?? null,
+                ]);
+
+                $accountEntity = AccountEntity::create([
+                    'name' => $remote['name'],
+                    'active' => true,
+                    'config_type' => 'account',
+                    'config_id' => $account->id,
+                    'user_id' => $user->id,
+                ]);
+            } else {
+                $account = $accountEntity->config;
+            }
+
+            foreach ($remote['transactions'] ?? [] as $tx) {
+                $date = Carbon::createFromTimestamp($tx['posted'])->format('Y-m-d');
+                $amount = (float) $tx['amount'];
+                $description = $tx['description'] ?? '';
+
+                $exists = Transaction::where('user_id', $user->id)
+                    ->where('date', $date)
+                    ->where('comment', $description)
+                    ->whereHas('config', function ($q) use ($accountEntity) {
+                        $q->where('account_from_id', $accountEntity->id)
+                          ->orWhere('account_to_id', $accountEntity->id);
+                    })
+                    ->exists();
+
+                if ($exists) {
+                    continue;
+                }
+
+                $typeName = $amount < 0 ? 'withdrawal' : 'deposit';
+                $type = TransactionType::where('name', $typeName)->first();
+
+                $detail = TransactionDetailStandard::create([
+                    $amount < 0 ? 'account_from_id' : 'account_to_id' => $accountEntity->id,
+                    'amount_from' => abs($amount),
+                    'amount_to' => abs($amount),
+                ]);
+
+                Transaction::create([
+                    'user_id' => $user->id,
+                    'date' => $date,
+                    'transaction_type_id' => $type->id,
+                    'reconciled' => true,
+                    'schedule' => false,
+                    'budget' => false,
+                    'comment' => $description,
+                    'config_type' => 'standard',
+                    'config_id' => $detail->id,
+                ]);
+            }
+        }
+    }
+}

--- a/config/yaffa.php
+++ b/config/yaffa.php
@@ -6,6 +6,7 @@ return [
 
     'admin_email' => env('ADMIN_EMAIL', 'admin@yaffa.test'),
     'alpha_vantage_key' => env('ALPHA_VANTAGE_KEY'),
+    'simplefin_access_url' => env('SIMPLEFIN_ACCESS_URL'),
     'registered_user_limit' => intval(env('REGISTERED_USER_LIMIT')),
     'incoming_receipts_email' => env('INCOMING_RECEIPTS_EMAIL'),
     'email_verification_required' =>env('EMAIL_VERIFICATION_REQUIRED',false),

--- a/database/factories/SimpleFinTokenFactory.php
+++ b/database/factories/SimpleFinTokenFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\SimpleFinToken;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class SimpleFinTokenFactory extends Factory
+{
+    protected $model = SimpleFinToken::class;
+
+    public function definition(): array
+    {
+        return [
+            'access_url' => 'https://demo:pass@beta-bridge.simplefin.org/simplefin/claim/DEMO',
+            'user_id' => User::factory(),
+        ];
+    }
+}
+

--- a/database/migrations/2025_06_22_213409_create_simplefin_tokens_table.php
+++ b/database/migrations/2025_06_22_213409_create_simplefin_tokens_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('simplefin_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(User::class)->constrained()->cascadeOnDelete();
+            $table->string('access_url');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('simplefin_tokens');
+    }
+};

--- a/database/migrations/2025_06_22_213413_add_simplefin_account_id_to_accounts_table.php
+++ b/database/migrations/2025_06_22_213413_add_simplefin_account_id_to_accounts_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('accounts', function (Blueprint $table) {
+            $table->string('simplefin_account_id')->nullable()->unique();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('accounts', function (Blueprint $table) {
+            $table->dropColumn('simplefin_account_id');
+        });
+    }
+};

--- a/tests/Unit/Console/Commands/SyncSimpleFinAccountsTest.php
+++ b/tests/Unit/Console/Commands/SyncSimpleFinAccountsTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Unit\Console\Commands;
+
+use App\Jobs\SyncSimpleFinAccounts;
+use App\Models\SimpleFinToken;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class SyncSimpleFinAccountsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const COMMAND = 'app:simplefin:sync';
+
+    /** @test */
+    public function dispatches_job_for_each_token(): void
+    {
+        $token = SimpleFinToken::factory()->create();
+
+        Queue::fake();
+
+        $this->artisan(self::COMMAND)->assertExitCode(0);
+
+        Queue::assertPushed(SyncSimpleFinAccounts::class, function ($job) use ($token) {
+            return $job->token->id === $token->id;
+        });
+    }
+}
+

--- a/tests/Unit/Services/SimpleFinServiceTest.php
+++ b/tests/Unit/Services/SimpleFinServiceTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\AccountGroup;
+use App\Models\Currency;
+use App\Models\SimpleFinToken;
+use App\Models\User;
+use App\Services\SimpleFinService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class SimpleFinServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function sync_creates_accounts_and_transactions(): void
+    {
+        $user = User::factory()->create();
+        Currency::factory()->for($user)->create(['base' => true]);
+        AccountGroup::factory()->for($user)->create();
+
+        $token = SimpleFinToken::factory()->for($user)->create();
+
+        $data = [
+            'accounts' => [
+                [
+                    'id' => 'demo',
+                    'name' => 'Demo Account',
+                    'balance' => 1000,
+                    'balance-date' => time(),
+                    'transactions' => [
+                        [
+                            'posted' => time(),
+                            'amount' => -50,
+                            'description' => 'Coffee',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        Http::fake([ '*' => Http::response($data, 200) ]);
+
+        $service = new SimpleFinService();
+        $service->sync($token);
+
+        $this->assertDatabaseHas('account_entities', [
+            'name' => 'Demo Account',
+            'user_id' => $user->id,
+        ]);
+
+        $this->assertDatabaseHas('transactions', [
+            'comment' => 'Coffee',
+            'user_id' => $user->id,
+        ]);
+    }
+}
+


### PR DESCRIPTION
## Summary
- integrate SimpleFIN Bridge support
- allow storing access URLs
- sync remote accounts and transactions
- expose `app:simplefin:sync` command
- test syncing and command dispatch

## Testing
- `vendor/bin/phpunit` *(fails: vendor/bin/phpunit: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685875e75308832f818afaca2278cade